### PR TITLE
feat: use cross-platform default delimiter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var minimatch = require('minimatch');
+var path = require('path');
 
 function IgnoreMatcher(str) {
   var negated = this.negated = [];
@@ -26,7 +27,7 @@ function IgnoreMatcher(str) {
   }).filter(Boolean);
   return this;
 }
-IgnoreMatcher.prototype.delimiter = '/';
+IgnoreMatcher.prototype.delimiter = path.sep;
 IgnoreMatcher.prototype.shouldIgnore = function (filename) {
   var isMatching = false;
   for (var i = 0; i < this.matchers.length; i++) {

--- a/test/test.js
+++ b/test/test.js
@@ -45,3 +45,7 @@ test('expected output', function (t) {
   t.end();
 });
 
+test('delimiter defaults to path.sep', function (t) {
+  t.equal(matcher.delimiter, path.sep);
+  t.end();
+});


### PR DESCRIPTION
Fixes #6.

Use [`path.sep`](https://nodejs.org/api/path.html#path_path_sep) as default delimiter instead of `'/'` to make dotignore Windows-friendly out-of-the-box.
  